### PR TITLE
Add a config option to skip SSL verification

### DIFF
--- a/s3/config.go
+++ b/s3/config.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"crypto/tls"
 	"net/http"
 	"net/url"
 	"time"
@@ -40,6 +41,11 @@ const (
 	// ConfigDisableSSL is optional config value for disabling SSL support on custom endpoints
 	// Its default value is "false", to disable SSL set it to "true".
 	ConfigDisableSSL = "disable_ssl"
+
+	// ConfigInsecureSkipSSLVerify is optional config value for skipping SSL certificate and hostname
+	// validation
+	// Its default value is "false", to disable SSL verfication set it to "true".
+	ConfigInsecureSkipSSLVerify = "insecure_skip_ssl_verify"
 )
 
 func init() {
@@ -101,8 +107,18 @@ func newS3Client(config stow.Config) (client *s3.S3, endpoint string, err error)
 		authType = "accesskey"
 	}
 
+	httpClient := http.DefaultClient
+	skipSSLVerify, ok := config.Config(ConfigInsecureSkipSSLVerify)
+	if ok && skipSSLVerify == "true" {
+		httpClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+	}
+
 	awsConfig := aws.NewConfig().
-		WithHTTPClient(http.DefaultClient).
+		WithHTTPClient(httpClient).
 		WithMaxRetries(aws.UseServiceDefaultRetries).
 		WithLogger(aws.NewDefaultLogger()).
 		WithLogLevel(aws.LogOff).

--- a/s3/config.go
+++ b/s3/config.go
@@ -108,8 +108,7 @@ func newS3Client(config stow.Config) (client *s3.S3, endpoint string, err error)
 	}
 
 	httpClient := http.DefaultClient
-	skipSSLVerify, ok := config.Config(ConfigInsecureSkipSSLVerify)
-	if ok && skipSSLVerify == "true" {
+	if skipSSLVerify, ok := config.Config(ConfigInsecureSkipSSLVerify); ok && skipSSLVerify == "true" {
 		httpClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,


### PR DESCRIPTION
Useful when using stow with test S3 implementations (e.g. minio) that use self signed certificates