### PR TITLE
Do not modify http.DefaultClient

### DIFF
--- a/s3/config.go
+++ b/s3/config.go
@@ -107,7 +107,7 @@ func newS3Client(config stow.Config) (client *s3.S3, endpoint string, err error)
 		authType = "accesskey"
 	}
 
-	httpClient := http.DefaultClient
+	httpClient := &http.Client{}
 	if skipSSLVerify, ok := config.Config(ConfigInsecureSkipSSLVerify); ok && skipSSLVerify == "true" {
 		httpClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{


### PR DESCRIPTION
Address @julio-lopez review feedback in #2 -

`DefaultClient` should not be used, even if that is what was used before.
This has a number of bad side effects. http.DefaultClient, is not only a shared instance, but is also of type *http.Client. So, a change to http.DefaultClient (or any aliasing reference) has effects on other "users / clients" of the same http client