### PR TITLE
Allow GCP buckets in other regions

### DIFF
--- a/google/config.go
+++ b/google/config.go
@@ -19,10 +19,10 @@ const Kind = "google"
 
 const (
 	// The service account json blob
-	ConfigJSON      = "json"
-	ConfigProjectId = "project_id"
-	ConfigScopes    = "scopes"
-	ConfigLocation = "Location"
+	ConfigJSON         = "json"
+	ConfigProjectId    = "project_id"
+	ConfigScopes       = "scopes"
+	ConfigLocation     = "Location"
 	ConfigStorageClass = "StorageClass"
 )
 

--- a/google/config.go
+++ b/google/config.go
@@ -22,6 +22,8 @@ const (
 	ConfigJSON      = "json"
 	ConfigProjectId = "project_id"
 	ConfigScopes    = "scopes"
+	ConfigLocation = "Location"
+	ConfigStorageClass = "StorageClass"
 )
 
 func init() {

--- a/google/location.go
+++ b/google/location.go
@@ -34,8 +34,8 @@ func (l *Location) CreateContainer(containerName string) (stow.Container, error)
 
 	// Create a bucket.
 	_, err := l.client.Buckets.Insert(projId, &storage.Bucket{
-		Name: containerName,
-		Location: location,
+		Name:         containerName,
+		Location:     location,
 		StorageClass: storageClass,
 	}).Do()
 	//res, err := l.client.Buckets.Insert(projId, &storage.Bucket{Name: containerName}).Do()

--- a/google/location.go
+++ b/google/location.go
@@ -29,8 +29,15 @@ func (l *Location) Close() error {
 func (l *Location) CreateContainer(containerName string) (stow.Container, error) {
 
 	projId, _ := l.config.Config(ConfigProjectId)
+	location, _ := l.config.Config(ConfigLocation)
+	storageClass, _ := l.config.Config(ConfigStorageClass)
+
 	// Create a bucket.
-	_, err := l.client.Buckets.Insert(projId, &storage.Bucket{Name: containerName}).Do()
+	_, err := l.client.Buckets.Insert(projId, &storage.Bucket{
+		Name: containerName,
+		Location: location,
+		StorageClass: storageClass,
+	}).Do()
 	//res, err := l.client.Buckets.Insert(projId, &storage.Bucket{Name: containerName}).Do()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR lets you create buckets in specific regions or a different multi_regional than US. Currently default args are used (StorageClass: "MULTI_REGIONAL", Location: "US"); Location default is mentioned [here](https://pkg.go.dev/cloud.google.com/go/storage@v0.38.0#BucketAttrs), StorageClass through testing. Settings are passed via config like S3 does with `ConfigRegion`.

Example test (placed inside google/stow_test in my case):

```
func TestRegionalBucket(t *testing.T) {
	fmt.Println("TestRegionalBucket......")
	projectId := "projectId goes here"
	configJSON := "configJSON goes here"
	bucket := "mimckayd-deltest"
	storageClass := "REGIONAL"
	location := "asia-south2"
	cm := stow.ConfigMap{}
	cm[ConfigJSON] = configJSON
	cm[ConfigProjectId] = projectId
	cm[ConfigScopes] = ""
	cm[ConfigLocation] = location
	cm[ConfigStorageClass] = storageClass
	l, err := stow.Dial(Kind, cm)
	if err != nil {
		t.Errorf("NO DIAL! %v", err)
	}
	fmt.Println("dialled...")
	container, err := l.CreateContainer(bucket)
	if err != nil {
		t.Errorf("NO BUCKET! %v", err)
	}
	fmt.Println("bucket created...", container.Name())
}
```

If you comment out ConfigLocation/ConfigStorageClass settings from the test then it defaults to US+MULTI_REGIONAL as in the 2nd test here so the default behaviour remains the same:
<img width="80%" alt="image" src="https://user-images.githubusercontent.com/93532247/180265556-9b1b7970-eabe-4651-a6b9-126c2233beba.png">

Location/StorageClass aren't required to delete a bucket etc + `stow.Walk` still works as expected even without Location details passed (bucket is enough):
```
func TestDeleteBucket(t *testing.T) {
	fmt.Println("TestDeleteBucket......")
	projectId := "projectId goes here"
	configJSON := "configJSON goes here"
	bucket := "mimckayd-deltest"
	cm := stow.ConfigMap{}
	cm[ConfigJSON] = configJSON
	cm[ConfigProjectId] = projectId
	cm[ConfigScopes] = ""
	l, err := stow.Dial(Kind, cm)
	if err != nil {
		t.Errorf("NO DIAL! %v", err)
	}
	fmt.Println("dialled...")
	err = l.RemoveContainer(bucket)
	if err != nil {
		t.Errorf("NO BUCKET DELETION! %v", err)
	}
	fmt.Println("bucket deleted...")
}
```