### PR TITLE
Expose Google Location via Container

### DIFF
--- a/google/config.go
+++ b/google/config.go
@@ -23,6 +23,7 @@ const (
 	ConfigProjectId = "project_id"
 	ConfigScopes    = "scopes"
 	ConfigLocation  = "Location"
+	ConfigStorageClass = "StorageClass"
 )
 
 func init() {

--- a/google/config.go
+++ b/google/config.go
@@ -19,11 +19,10 @@ const Kind = "google"
 
 const (
 	// The service account json blob
-	ConfigJSON         = "json"
-	ConfigProjectId    = "project_id"
-	ConfigScopes       = "scopes"
-	ConfigLocation     = "Location"
-	ConfigStorageClass = "StorageClass"
+	ConfigJSON      = "json"
+	ConfigProjectId = "project_id"
+	ConfigScopes    = "scopes"
+	ConfigLocation  = "Location"
 )
 
 func init() {

--- a/google/config.go
+++ b/google/config.go
@@ -19,10 +19,10 @@ const Kind = "google"
 
 const (
 	// The service account json blob
-	ConfigJSON      = "json"
-	ConfigProjectId = "project_id"
-	ConfigScopes    = "scopes"
-	ConfigLocation  = "Location"
+	ConfigJSON         = "json"
+	ConfigProjectId    = "project_id"
+	ConfigScopes       = "scopes"
+	ConfigLocation     = "Location"
 	ConfigStorageClass = "StorageClass"
 )
 

--- a/google/container.go
+++ b/google/container.go
@@ -16,8 +16,7 @@ type Container struct {
 	// Client is responsible for performing the requests.
 	client *storage.Service
 
-	location     string
-	storageClass string
+	location string
 }
 
 // ID returns a string value which represents the name of the container.
@@ -31,14 +30,9 @@ func (c *Container) Name() string {
 }
 
 // Location returns a string representing the region of the container.
+// See https://pkg.go.dev/cloud.google.com/go/storage@v0.38.0#BucketAttrs
 func (c *Container) Location() string {
 	return c.location
-}
-
-// StorageClass returns the type of container e.g. REGIONAL or MULTI_REGIONAL.
-// See https://pkg.go.dev/cloud.google.com/go/storage@v0.38.0#BucketAttrs
-func (c *Container) StorageClass() string {
-	return c.storageClass
 }
 
 func (c *Container) Bucket() (*storage.Bucket, error) {

--- a/google/container.go
+++ b/google/container.go
@@ -16,7 +16,7 @@ type Container struct {
 	// Client is responsible for performing the requests.
 	client *storage.Service
 
-	location string
+	location     string
 	storageClass string
 }
 

--- a/google/container.go
+++ b/google/container.go
@@ -15,6 +15,9 @@ type Container struct {
 
 	// Client is responsible for performing the requests.
 	client *storage.Service
+
+	location string
+	storageClass string
 }
 
 // ID returns a string value which represents the name of the container.
@@ -25,6 +28,17 @@ func (c *Container) ID() string {
 // Name returns a string value which represents the name of the container.
 func (c *Container) Name() string {
 	return c.name
+}
+
+// Location returns a string representing the region of the container.
+func (c *Container) Location() string {
+	return c.location
+}
+
+// StorageClass returns the type of container e.g. REGIONAL or MULTI_REGIONAL.
+// See https://pkg.go.dev/cloud.google.com/go/storage@v0.38.0#BucketAttrs
+func (c *Container) StorageClass() string {
+	return c.storageClass
 }
 
 func (c *Container) Bucket() (*storage.Bucket, error) {

--- a/google/location.go
+++ b/google/location.go
@@ -30,13 +30,11 @@ func (l *Location) CreateContainer(containerName string) (stow.Container, error)
 
 	projId, _ := l.config.Config(ConfigProjectId)
 	location, _ := l.config.Config(ConfigLocation)
-	storageClass, _ := l.config.Config(ConfigStorageClass)
 
 	// Create a bucket.
 	b, err := l.client.Buckets.Insert(projId, &storage.Bucket{
-		Name:         containerName,
-		Location:     location,
-		StorageClass: storageClass,
+		Name:     containerName,
+		Location: location,
 	}).Do()
 	//res, err := l.client.Buckets.Insert(projId, &storage.Bucket{Name: containerName}).Do()
 	if err != nil {
@@ -44,10 +42,9 @@ func (l *Location) CreateContainer(containerName string) (stow.Container, error)
 	}
 
 	newContainer := &Container{
-		name:         containerName,
-		client:       l.client,
-		location:     b.Location,
-		storageClass: b.StorageClass,
+		name:     containerName,
+		client:   l.client,
+		location: b.Location,
 	}
 
 	return newContainer, nil
@@ -77,10 +74,9 @@ func (l *Location) Containers(prefix string, cursor string, count int) ([]stow.C
 
 	for i, o := range res.Items {
 		containers[i] = &Container{
-			name:         o.Name,
-			client:       l.client,
-			location:     o.Location,
-			storageClass: o.StorageClass,
+			name:     o.Name,
+			client:   l.client,
+			location: o.Location,
 		}
 	}
 
@@ -97,10 +93,9 @@ func (l *Location) Container(id string) (stow.Container, error) {
 	}
 
 	c := &Container{
-		name:         id,
-		client:       l.client,
-		location:     b.Location,
-		storageClass: b.StorageClass,
+		name:     id,
+		client:   l.client,
+		location: b.Location,
 	}
 
 	return c, nil

--- a/google/location.go
+++ b/google/location.go
@@ -33,7 +33,7 @@ func (l *Location) CreateContainer(containerName string) (stow.Container, error)
 	storageClass, _ := l.config.Config(ConfigStorageClass)
 
 	// Create a bucket.
-	_, err := l.client.Buckets.Insert(projId, &storage.Bucket{
+	b, err := l.client.Buckets.Insert(projId, &storage.Bucket{
 		Name:         containerName,
 		Location:     location,
 		StorageClass: storageClass,
@@ -44,8 +44,10 @@ func (l *Location) CreateContainer(containerName string) (stow.Container, error)
 	}
 
 	newContainer := &Container{
-		name:   containerName,
-		client: l.client,
+		name:         containerName,
+		client:       l.client,
+		location:     b.Location,
+		storageClass: b.StorageClass,
 	}
 
 	return newContainer, nil

--- a/google/location.go
+++ b/google/location.go
@@ -77,8 +77,10 @@ func (l *Location) Containers(prefix string, cursor string, count int) ([]stow.C
 
 	for i, o := range res.Items {
 		containers[i] = &Container{
-			name:   o.Name,
-			client: l.client,
+			name:         o.Name,
+			client:       l.client,
+			location:     o.Location,
+			storageClass: o.StorageClass,
 		}
 	}
 
@@ -89,14 +91,16 @@ func (l *Location) Containers(prefix string, cursor string, count int) ([]stow.C
 // exact.
 func (l *Location) Container(id string) (stow.Container, error) {
 
-	_, err := l.client.Buckets.Get(id).Do()
+	b, err := l.client.Buckets.Get(id).Do()
 	if err != nil {
 		return nil, stow.ErrNotFound
 	}
 
 	c := &Container{
-		name:   id,
-		client: l.client,
+		name:         id,
+		client:       l.client,
+		location:     b.Location,
+		storageClass: b.StorageClass,
 	}
 
 	return c, nil

--- a/google/location.go
+++ b/google/location.go
@@ -30,11 +30,13 @@ func (l *Location) CreateContainer(containerName string) (stow.Container, error)
 
 	projId, _ := l.config.Config(ConfigProjectId)
 	location, _ := l.config.Config(ConfigLocation)
+	storageClass, _ := l.config.Config(ConfigStorageClass)
 
 	// Create a bucket.
 	b, err := l.client.Buckets.Insert(projId, &storage.Bucket{
-		Name:     containerName,
-		Location: location,
+		Name:         containerName,
+		Location:     location,
+		StorageClass: storageClass,
 	}).Do()
 	//res, err := l.client.Buckets.Insert(projId, &storage.Bucket{Name: containerName}).Do()
 	if err != nil {


### PR DESCRIPTION
Adds functions & properties to the Google container. I did the same style as S3 container (rather than just exporting the props directly.

Without this we know a bucket was created but cannot confirm it was created in the location we expected

Not sure it's worth adding an interface to all of stow.Container, small stepping stone instead

Test ran from `google/stow_test.go`:

```
func TestRegionalBucket(t *testing.T) {
	fmt.Println("TestRegionalBucket......")
	projectId := "projectId goes here"
	configJSON := "configJSON goes here"
	bucket := "mimckayd-melb"
	location := "australia-southeast2"
	cm := stow.ConfigMap{}
	cm[ConfigJSON] = configJSON
	cm[ConfigProjectId] = projectId
	cm[ConfigScopes] = ""
	cm[ConfigLocation] = location
	l, err := stow.Dial(Kind, cm)
	if err != nil {
		t.Errorf("NO DIAL! %v", err)
	}
	fmt.Println("dialled...")
	container, err := l.CreateContainer(bucket)
	if err != nil {
		t.Errorf("NO BUCKET! %v", err)
	}
	fmt.Println("bucket created...", container.Name())
}
```

Result:
<img width="650" alt="image" src="https://user-images.githubusercontent.com/93532247/181741971-8b46777a-cd5c-49dc-b94f-28243c9b44f1.png">
