### PR TITLE
Updated error message for HeadBucket and update unit tests

### DIFF
--- a/s3/location.go
+++ b/s3/location.go
@@ -170,7 +170,7 @@ func (l *location) Container(id string) (stow.Container, error) {
 			return nil, stow.ErrNotFound
 		}
 
-		return nil, errors.Wrap(err, "GetBucketLocation")
+		return nil, errors.Wrap(err, "HeadBucket")
 	}
 
 	c := &container{

--- a/s3/stow_test.go
+++ b/s3/stow_test.go
@@ -2,7 +2,6 @@
 package s3
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/cheekybits/is"
 	"github.com/graymeta/stow"
 	"github.com/graymeta/stow/test"
@@ -152,41 +150,12 @@ func TestV2SigningEnabled(t *testing.T) {
 	_, _ = location.ItemByURL(uri)
 }
 
-func TestWillNotRequestRegionWhenConfigured(t *testing.T) {
+func TestWillRequestWhenConfigured(t *testing.T) {
 	is := is.New(t)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		is.Fail("Request should not occur")
-		w.WriteHeader(http.StatusBadRequest)
-	}))
-	defer server.Close()
-
-	config := stow.ConfigMap{
-		"access_key_id": "access-key",
-		"secret_key":    "secret-key",
-		"region":        "do-not-care",
-		"endpoint":      server.URL,
-	}
-
-	location, err := stow.Dial("s3", config)
-	is.NoErr(err)
-
-	_, err = location.Container("Whatever")
-
-	is.NoErr(err)
-}
-
-func TestWillRequestRegionWhenConfigured(t *testing.T) {
-	is := is.New(t)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		awsLocationQuery, err := url.ParseQuery("location")
-		is.NoErr(err)
-		is.Equal(awsLocationQuery.Encode(), r.URL.RawQuery)
-		b, _ := json.Marshal(s3.GetBucketLocationOutput{
-			LocationConstraint: aws.String("whatever"),
-		})
-		w.Write(b)
+		is.Equal(strings.TrimPrefix(r.URL.String(), "/"), "BucketName")
+		is.Equal(r.Method, "HEAD")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -200,7 +169,7 @@ func TestWillRequestRegionWhenConfigured(t *testing.T) {
 	location, err := stow.Dial("s3", config)
 	is.NoErr(err)
 
-	_, err = location.Container("Whatever")
+	_, err = location.Container("BucketName")
 
 	// Make sure that this is an error
 	is.NoErr(err)

--- a/s3/stow_test.go
+++ b/s3/stow_test.go
@@ -150,7 +150,7 @@ func TestV2SigningEnabled(t *testing.T) {
 	_, _ = location.ItemByURL(uri)
 }
 
-func TestWillRequestWhenConfigured(t *testing.T) {
+func TestHeadBucketContainerCall(t *testing.T) {
 	is := is.New(t)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Following up on https://github.com/kastenhq/stow/pull/30 and fixing the error message to reflect the method change. Also updated the unit tests.