### PR TITLE
fix(s3): default missing storage class to STANDARD for S3-compatible providers

### DIFF
--- a/s3/container.go
+++ b/s3/container.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"bytes"
 	"io"
-	"log"
 	"io/ioutil"
 	"strings"
 
@@ -65,7 +64,10 @@ func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string
 	for _, object := range response.Contents {
 		if object.StorageClass == nil {
 			if object.Key != nil {
-				log.Printf("Return Storage Class is empty for object %s \n", *object.Key)
+				// AWS S3 spec allows omitting the storage class for STANDARD tier objects.
+				// Default to STANDARD.
+				standardStorageClass := "STANDARD"
+				object.StorageClass = &standardStorageClass
 			}
 			continue
 		}

--- a/s3/container.go
+++ b/s3/container.go
@@ -68,7 +68,8 @@ func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string
 			}
 			// AWS S3 spec allows omitting the storage class for STANDARD tier objects.
 			// Default to STANDARD.
-			object.StorageClass = aws.String("STANDARD")
+			standardStorageClass := "STANDARD"
+			object.StorageClass = &standardStorageClass
 		}
 		if *object.StorageClass == "GLACIER" {
 			continue

--- a/s3/container.go
+++ b/s3/container.go
@@ -69,7 +69,6 @@ func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string
 				standardStorageClass := "STANDARD"
 				object.StorageClass = &standardStorageClass
 			}
-			continue
 		}
 		if *object.StorageClass == "GLACIER" {
 			continue

--- a/s3/container.go
+++ b/s3/container.go
@@ -63,12 +63,12 @@ func (c *container) Items(prefix, cursor string, count int) ([]stow.Item, string
 
 	for _, object := range response.Contents {
 		if object.StorageClass == nil {
-			if object.Key != nil {
-				// AWS S3 spec allows omitting the storage class for STANDARD tier objects.
-				// Default to STANDARD.
-				standardStorageClass := "STANDARD"
-				object.StorageClass = &standardStorageClass
+			if object.Key == nil {
+				continue
 			}
+			// AWS S3 spec allows omitting the storage class for STANDARD tier objects.
+			// Default to STANDARD.
+			object.StorageClass = aws.String("STANDARD")
 		}
 		if *object.StorageClass == "GLACIER" {
 			continue


### PR DESCRIPTION
### What this PR does / why we need it:
This PR fixes a critical idempotency and listing bug when using Kanister/stow with S3-compatible storage providers like NetApp ONTAP S3, StorageGRID, and MinIO.

Currently, if an S3 ListObjectsV2 endpoint omits the `<StorageClass>` in response for objects in the default `STANDARD` tier (which is permitted by the AWS S3 specification), `stow` explicitly throws an error (`storage class is empty for object...`). 

In Kanister, this causes the data mover to drop the object from the inventory. When running `kando location delete`, this results in a false positive: the system assumes the object doesn't exist, skips the actual deletion API call, and reports a "success" while leaving the orphaned data in the S3 bucket.

### The Fix:
Instead of skipping the object when `StorageClass` is `nil`, this patch gracefully defaults the value to `"STANDARD"`. This aligns with AWS API documentation and restores compatibility with strictly-compliant on-premises S3 gateways without breaking native AWS behavior.

### Steps to Reproduce the Bug:
1. Back up data via Kanister to NetApp ONTAP S3 (which omits the storage class header for standard tier).
2. Run `kando location delete`.
3. Check S3 bucket: `kando` completes successfully, but the file remains in the bucket. Kando logs show: `return storage class is empty for object...`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of S3 objects with missing storage class information by automatically applying a default classification instead of generating log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->