### PR TITLE
Add SAS token authentication support to Azure driver

### DIFF
--- a/azure/config.go
+++ b/azure/config.go
@@ -9,16 +9,28 @@ import (
 	"github.com/graymeta/stow"
 )
 
-// ConfigAccount and ConfigKey are the supported configuration items for
-// Azure blob storage.
+// ConfigAccount, ConfigKey, and ConfigSASToken are the supported
+// configuration items for Azure blob storage. Either ConfigKey or
+// ConfigSASToken must be present; ConfigSASToken is an alternative to
+// ConfigKey, not additive.
 const (
-	ConfigAccount = "account"
-	ConfigKey     = "key"
-	ConfigEnvName = "envname"
+	ConfigAccount  = "account"
+	ConfigKey      = "key"
+	ConfigEnvName  = "envname"
+	ConfigSASToken = "sastoken"
 )
 
 // Kind is the kind of Location this package provides.
 const Kind = "azure"
+
+func hasAuth(config stow.Config) bool {
+	key, ok := config.Config(ConfigKey)
+	if ok && key != "" {
+		return true
+	}
+	sasToken, ok := config.Config(ConfigSASToken)
+	return ok && sasToken != ""
+}
 
 func init() {
 	validatefn := func(config stow.Config) error {
@@ -26,9 +38,8 @@ func init() {
 		if !ok {
 			return errors.New("missing account id")
 		}
-		_, ok = config.Config(ConfigKey)
-		if !ok {
-			return errors.New("missing auth key")
+		if !hasAuth(config) {
+			return errors.New("missing auth key or sas token")
 		}
 		return nil
 	}
@@ -37,9 +48,8 @@ func init() {
 		if !ok {
 			return nil, errors.New("missing account id")
 		}
-		_, ok = config.Config(ConfigKey)
-		if !ok {
-			return nil, errors.New("missing auth key")
+		if !hasAuth(config) {
+			return nil, errors.New("missing auth key or sas token")
 		}
 		l := &location{
 			config: config,
@@ -67,6 +77,27 @@ func newBlobStorageClient(cfg stow.Config) (*az.BlobStorageClient, error) {
 	if !ok {
 		return nil, errors.New("missing account id")
 	}
+
+	env := azure.PublicCloud
+	envName, ok := cfg.Config(ConfigEnvName)
+	if ok && envName != "" {
+		var err error
+		env, err = azure.EnvironmentFromName(envName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if sasToken, ok := cfg.Config(ConfigSASToken); ok && sasToken != "" {
+		endpoint := "https://" + acc + ".blob." + env.StorageEndpointSuffix
+		sasClient, err := az.NewAccountSASClientFromEndpointToken(endpoint, sasToken)
+		if err != nil {
+			return nil, errors.New("bad credentials")
+		}
+		client := sasClient.GetBlobService()
+		return &client, nil
+	}
+
 	key, ok := cfg.Config(ConfigKey)
 	if !ok {
 		return nil, errors.New("missing auth key")
@@ -74,13 +105,7 @@ func newBlobStorageClient(cfg stow.Config) (*az.BlobStorageClient, error) {
 
 	var basicClient az.Client
 	var err error
-	envName, ok := cfg.Config(ConfigEnvName)
-	if ok && envName != "" {
-		var env azure.Environment
-		env, err = azure.EnvironmentFromName(envName)
-		if err != nil {
-			return nil, err
-		}
+	if envName != "" {
 		basicClient, err = az.NewBasicClientOnSovereignCloud(acc, key, env)
 	} else {
 		basicClient, err = az.NewBasicClient(acc, key)

--- a/azure/config.go
+++ b/azure/config.go
@@ -11,10 +11,9 @@ import (
 )
 
 // ConfigAccount, ConfigKey, and ConfigSASToken are the supported
-// configuration items for Azure blob storage. At least one of ConfigKey or
-// ConfigSASToken must be present. ConfigSASToken is an alternative to
-// ConfigKey, not additive; if both are supplied, ConfigSASToken takes
-// precedence (see newBlobStorageClient).
+// configuration items for Azure blob storage. ConfigSASToken is an
+// alternative to ConfigKey; if both are set, ConfigSASToken wins (see
+// newBlobStorageClient).
 const (
 	ConfigAccount  = "account"
 	ConfigKey      = "key"
@@ -33,23 +32,16 @@ func hasAuth(config stow.Config) bool {
 	return usingSASToken(config)
 }
 
-// usingSASToken reports whether the config authenticates with a SAS token
-// rather than a shared account key. SAS tokens minted for Azure Workload
-// (federated) Identity are user-delegation SAS: they are scoped to a single
-// container and cannot perform account-level operations such as listing
-// containers, so callers must avoid account-level actions on this path.
 func usingSASToken(config stow.Config) bool {
 	sasToken, ok := config.Config(ConfigSASToken)
 	return ok && sasToken != ""
 }
 
-// requireHTTPSSASProtocol rejects a SAS token whose signed protocol (spr) would
-// permit non-HTTPS transport. The Azure storage SDK derives the request scheme
-// from spr: newSASClient sets useHTTPS = (spr == "https") for any non-empty spr,
-// which overrides the endpoint scheme, so a token with spr=https,http makes the
-// client send requests over plaintext HTTP even against an https:// endpoint. An
-// empty spr is allowed — the SDK then infers the scheme from the (https)
-// endpoint. Parsed exactly as the SDK does (url.ParseQuery + Get("spr")).
+// requireHTTPSSASProtocol rejects a SAS token whose spr parameter would let
+// the Azure SDK downgrade to HTTP: a non-empty spr overrides the endpoint
+// scheme, so spr=https,http would send requests in plaintext even against
+// an https:// endpoint. An empty spr is fine — the SDK falls back to the
+// endpoint's scheme.
 func requireHTTPSSASProtocol(sasToken string) error {
 	values, err := url.ParseQuery(sasToken)
 	if err != nil {
@@ -88,10 +80,9 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		// A user-delegation SAS token (Azure Workload Identity) is scoped to a
-		// single container and cannot list containers at the account level, so
-		// skip the account-level connection probe on the SAS path. Access is
-		// validated when the caller operates on its specific container.
+		// A SAS token is scoped to a single container and can't list
+		// containers at the account level, so skip the probe here; access is
+		// checked when the caller uses its container.
 		if !usingSASToken(config) {
 			// test the connection
 			if _, _, err = l.Containers("", stow.CursorStart, 1); err != nil {
@@ -122,9 +113,7 @@ func newBlobStorageClient(cfg stow.Config) (*az.BlobStorageClient, error) {
 		}
 	}
 
-	// SAS token takes precedence over a shared account key: it is checked first,
-	// so if both are set (they are alternatives, not additive) the SAS token
-	// wins. See the ConfigSASToken doc.
+	// SAS token takes precedence over the account key (see ConfigSASToken doc).
 	if sasToken, ok := cfg.Config(ConfigSASToken); ok && sasToken != "" {
 		if err := requireHTTPSSASProtocol(sasToken); err != nil {
 			return nil, err

--- a/azure/config.go
+++ b/azure/config.go
@@ -43,6 +43,24 @@ func usingSASToken(config stow.Config) bool {
 	return ok && sasToken != ""
 }
 
+// requireHTTPSSASProtocol rejects a SAS token whose signed protocol (spr) would
+// permit non-HTTPS transport. The Azure storage SDK derives the request scheme
+// from spr: newSASClient sets useHTTPS = (spr == "https") for any non-empty spr,
+// which overrides the endpoint scheme, so a token with spr=https,http makes the
+// client send requests over plaintext HTTP even against an https:// endpoint. An
+// empty spr is allowed — the SDK then infers the scheme from the (https)
+// endpoint. Parsed exactly as the SDK does (url.ParseQuery + Get("spr")).
+func requireHTTPSSASProtocol(sasToken string) error {
+	values, err := url.ParseQuery(sasToken)
+	if err != nil {
+		return fmt.Errorf("bad credentials: invalid SAS token: %w", err)
+	}
+	if spr := values.Get("spr"); spr != "" && spr != "https" {
+		return fmt.Errorf("bad credentials: SAS token allows non-HTTPS transport (spr=%q); only https is permitted", spr)
+	}
+	return nil
+}
+
 func init() {
 	validatefn := func(config stow.Config) error {
 		_, ok := config.Config(ConfigAccount)
@@ -108,6 +126,9 @@ func newBlobStorageClient(cfg stow.Config) (*az.BlobStorageClient, error) {
 	// so if both are set (they are alternatives, not additive) the SAS token
 	// wins. See the ConfigSASToken doc.
 	if sasToken, ok := cfg.Config(ConfigSASToken); ok && sasToken != "" {
+		if err := requireHTTPSSASProtocol(sasToken); err != nil {
+			return nil, err
+		}
 		endpoint := "https://" + acc + ".blob." + env.StorageEndpointSuffix
 		sasClient, err := az.NewAccountSASClientFromEndpointToken(endpoint, sasToken)
 		if err != nil {

--- a/azure/config.go
+++ b/azure/config.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 
 	az "github.com/Azure/azure-sdk-for-go/storage"
@@ -10,9 +11,10 @@ import (
 )
 
 // ConfigAccount, ConfigKey, and ConfigSASToken are the supported
-// configuration items for Azure blob storage. Either ConfigKey or
-// ConfigSASToken must be present; ConfigSASToken is an alternative to
-// ConfigKey, not additive.
+// configuration items for Azure blob storage. At least one of ConfigKey or
+// ConfigSASToken must be present. ConfigSASToken is an alternative to
+// ConfigKey, not additive; if both are supplied, ConfigSASToken takes
+// precedence (see newBlobStorageClient).
 const (
 	ConfigAccount  = "account"
 	ConfigKey      = "key"
@@ -102,11 +104,14 @@ func newBlobStorageClient(cfg stow.Config) (*az.BlobStorageClient, error) {
 		}
 	}
 
+	// SAS token takes precedence over a shared account key: it is checked first,
+	// so if both are set (they are alternatives, not additive) the SAS token
+	// wins. See the ConfigSASToken doc.
 	if sasToken, ok := cfg.Config(ConfigSASToken); ok && sasToken != "" {
 		endpoint := "https://" + acc + ".blob." + env.StorageEndpointSuffix
 		sasClient, err := az.NewAccountSASClientFromEndpointToken(endpoint, sasToken)
 		if err != nil {
-			return nil, errors.New("bad credentials")
+			return nil, fmt.Errorf("bad credentials: %w", err)
 		}
 		client := sasClient.GetBlobService()
 		return &client, nil
@@ -126,7 +131,7 @@ func newBlobStorageClient(cfg stow.Config) (*az.BlobStorageClient, error) {
 	}
 
 	if err != nil {
-		return nil, errors.New("bad credentials")
+		return nil, fmt.Errorf("bad credentials: %w", err)
 	}
 	client := basicClient.GetBlobService()
 	return &client, err

--- a/azure/config.go
+++ b/azure/config.go
@@ -32,16 +32,18 @@ func hasAuth(config stow.Config) bool {
 	return usingSASToken(config)
 }
 
+// usingSASToken reports whether the config authenticates with a SAS token.
+// User-delegation SAS (Azure Workload Identity) is container-scoped and cannot
+// perform account-level operations, so callers must avoid them on this path.
 func usingSASToken(config stow.Config) bool {
 	sasToken, ok := config.Config(ConfigSASToken)
 	return ok && sasToken != ""
 }
 
-// requireHTTPSSASProtocol rejects a SAS token whose spr parameter would let
-// the Azure SDK downgrade to HTTP: a non-empty spr overrides the endpoint
-// scheme, so spr=https,http would send requests in plaintext even against
-// an https:// endpoint. An empty spr is fine — the SDK falls back to the
-// endpoint's scheme.
+// requireHTTPSSASProtocol rejects a SAS token whose signed protocol (spr) would
+// permit non-HTTPS transport. The SDK sets useHTTPS = (spr == "https") for any
+// non-empty spr, so spr=https,http would send requests over plaintext HTTP even
+// against an https:// endpoint. Empty spr is fine (scheme inferred from endpoint).
 func requireHTTPSSASProtocol(sasToken string) error {
 	values, err := url.ParseQuery(sasToken)
 	if err != nil {
@@ -80,9 +82,8 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		// A SAS token is scoped to a single container and can't list
-		// containers at the account level, so skip the probe here; access is
-		// checked when the caller uses its container.
+		// User-delegation SAS is container-scoped and cannot list containers, so
+		// skip the account-level connection probe; access is checked per-container.
 		if !usingSASToken(config) {
 			// test the connection
 			if _, _, err = l.Containers("", stow.CursorStart, 1); err != nil {
@@ -113,10 +114,15 @@ func newBlobStorageClient(cfg stow.Config) (*az.BlobStorageClient, error) {
 		}
 	}
 
-	// SAS token takes precedence over the account key (see ConfigSASToken doc).
+	// SAS token wins over ConfigKey when both are set (see ConfigSASToken doc).
 	if sasToken, ok := cfg.Config(ConfigSASToken); ok && sasToken != "" {
 		if err := requireHTTPSSASProtocol(sasToken); err != nil {
 			return nil, err
+		}
+		// The key path validates the account inside NewBasicClient; the SAS path
+		// builds the endpoint URL by hand, so validate the account name here too.
+		if !az.IsValidStorageAccount(acc) {
+			return nil, fmt.Errorf("bad credentials: invalid storage account name %q", acc)
 		}
 		endpoint := "https://" + acc + ".blob." + env.StorageEndpointSuffix
 		sasClient, err := az.NewAccountSASClientFromEndpointToken(endpoint, sasToken)

--- a/azure/config.go
+++ b/azure/config.go
@@ -28,6 +28,15 @@ func hasAuth(config stow.Config) bool {
 	if ok && key != "" {
 		return true
 	}
+	return usingSASToken(config)
+}
+
+// usingSASToken reports whether the config authenticates with a SAS token
+// rather than a shared account key. SAS tokens minted for Azure Workload
+// (federated) Identity are user-delegation SAS: they are scoped to a single
+// container and cannot perform account-level operations such as listing
+// containers, so callers must avoid account-level actions on this path.
+func usingSASToken(config stow.Config) bool {
 	sasToken, ok := config.Config(ConfigSASToken)
 	return ok && sasToken != ""
 }
@@ -59,10 +68,15 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		// test the connection
-		_, _, err = l.Containers("", stow.CursorStart, 1)
-		if err != nil {
-			return nil, err
+		// A user-delegation SAS token (Azure Workload Identity) is scoped to a
+		// single container and cannot list containers at the account level, so
+		// skip the account-level connection probe on the SAS path. Access is
+		// validated when the caller operates on its specific container.
+		if !usingSASToken(config) {
+			// test the connection
+			if _, _, err = l.Containers("", stow.CursorStart, 1); err != nil {
+				return nil, err
+			}
 		}
 		return l, nil
 	}

--- a/azure/config_test.go
+++ b/azure/config_test.go
@@ -43,6 +43,20 @@ func TestNewBlobStorageClientAcceptsHTTPSSASProtocol(t *testing.T) {
 	is.NotNil(client)
 }
 
+func TestNewBlobStorageClientRejectsInvalidAccountOnSASPath(t *testing.T) {
+	is := is.New(t)
+
+	// A malformed account name would otherwise be baked into the endpoint URL
+	// and surface as a confusing wrong-endpoint error instead of a bad account.
+	cfg := stow.ConfigMap{
+		ConfigAccount:  "Invalid_Account",
+		ConfigSASToken: "sv=2020-08-04&ss=b&srt=sco&sp=rwdlac&spr=https&se=2099-01-01T00:00:00Z&sig=abc123",
+	}
+	client, err := newBlobStorageClient(cfg)
+	is.Err(err)
+	is.Nil(client)
+}
+
 func TestValidateAcceptsAccountAndSASTokenWithoutKey(t *testing.T) {
 	is := is.New(t)
 

--- a/azure/config_test.go
+++ b/azure/config_test.go
@@ -19,6 +19,33 @@ func TestNewBlobStorageClientSASToken(t *testing.T) {
 	is.NotNil(client)
 }
 
+func TestNewBlobStorageClientRejectsNonHTTPSSASProtocol(t *testing.T) {
+	is := is.New(t)
+
+	// spr=https,http would make the Azure SDK send requests over plaintext HTTP
+	// (useHTTPS = spr == "https"), overriding the https:// endpoint. Reject it.
+	cfg := stow.ConfigMap{
+		ConfigAccount:  "testaccount",
+		ConfigSASToken: "sv=2020-08-04&ss=b&srt=sco&sp=rwdlac&spr=https,http&se=2099-01-01T00:00:00Z&sig=abc123",
+	}
+	client, err := newBlobStorageClient(cfg)
+	is.Err(err)
+	is.Nil(client)
+}
+
+func TestNewBlobStorageClientAcceptsHTTPSSASProtocol(t *testing.T) {
+	is := is.New(t)
+
+	// An explicit spr=https is the secure case and must keep working.
+	cfg := stow.ConfigMap{
+		ConfigAccount:  "testaccount",
+		ConfigSASToken: "sv=2020-08-04&ss=b&srt=sco&sp=rwdlac&spr=https&se=2099-01-01T00:00:00Z&sig=abc123",
+	}
+	client, err := newBlobStorageClient(cfg)
+	is.NoErr(err)
+	is.NotNil(client)
+}
+
 func TestValidateAcceptsAccountAndSASTokenWithoutKey(t *testing.T) {
 	is := is.New(t)
 

--- a/azure/config_test.go
+++ b/azure/config_test.go
@@ -1,0 +1,39 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/cheekybits/is"
+	"github.com/graymeta/stow"
+)
+
+func TestNewBlobStorageClientSASToken(t *testing.T) {
+	is := is.New(t)
+
+	cfg := stow.ConfigMap{
+		ConfigAccount:  "testaccount",
+		ConfigSASToken: "sv=2020-08-04&ss=b&srt=sco&sp=rwdlac&se=2099-01-01T00:00:00Z&sig=abc123",
+	}
+	client, err := newBlobStorageClient(cfg)
+	is.NoErr(err)
+	is.NotNil(client)
+}
+
+func TestValidateAcceptsAccountAndSASTokenWithoutKey(t *testing.T) {
+	is := is.New(t)
+
+	cfg := stow.ConfigMap{
+		ConfigAccount:  "testaccount",
+		ConfigSASToken: "sv=2020-08-04&ss=b&srt=sco&sp=rwdlac&se=2099-01-01T00:00:00Z&sig=abc123",
+	}
+	is.True(hasAuth(cfg))
+}
+
+func TestValidateRejectsAccountOnly(t *testing.T) {
+	is := is.New(t)
+
+	cfg := stow.ConfigMap{
+		ConfigAccount: "testaccount",
+	}
+	is.False(hasAuth(cfg))
+}

--- a/azure/config_test.go
+++ b/azure/config_test.go
@@ -22,8 +22,6 @@ func TestNewBlobStorageClientSASToken(t *testing.T) {
 func TestNewBlobStorageClientRejectsNonHTTPSSASProtocol(t *testing.T) {
 	is := is.New(t)
 
-	// spr=https,http would make the Azure SDK send requests over plaintext HTTP
-	// (useHTTPS = spr == "https"), overriding the https:// endpoint. Reject it.
 	cfg := stow.ConfigMap{
 		ConfigAccount:  "testaccount",
 		ConfigSASToken: "sv=2020-08-04&ss=b&srt=sco&sp=rwdlac&spr=https,http&se=2099-01-01T00:00:00Z&sig=abc123",
@@ -36,7 +34,6 @@ func TestNewBlobStorageClientRejectsNonHTTPSSASProtocol(t *testing.T) {
 func TestNewBlobStorageClientAcceptsHTTPSSASProtocol(t *testing.T) {
 	is := is.New(t)
 
-	// An explicit spr=https is the secure case and must keep working.
 	cfg := stow.ConfigMap{
 		ConfigAccount:  "testaccount",
 		ConfigSASToken: "sv=2020-08-04&ss=b&srt=sco&sp=rwdlac&spr=https&se=2099-01-01T00:00:00Z&sig=abc123",

--- a/azure/location.go
+++ b/azure/location.go
@@ -63,18 +63,16 @@ func (l *location) Containers(prefix, cursor string, count int) ([]stow.Containe
 
 func (l *location) Container(id string) (stow.Container, error) {
 	// A user-delegation SAS token (Azure Workload Identity) is scoped to this
-	// container and cannot list containers at the account level. Reference the
-	// container directly and confirm it with a container-scoped existence check
-	// instead of enumerating.
+	// single container (sr=c) and is authorized only for blob operations WITHIN
+	// the container. Container-level operations — listing containers, and also
+	// "Get Container Properties" (which ref.Exists() issues) — require an
+	// account-level SAS (srt=service/container/object) and return HTTP 403 with
+	// a container-scoped token, regardless of the SAS permissions or the
+	// delegated identity's RBAC. So reference the container directly without any
+	// existence/property probe; a genuinely missing container surfaces on the
+	// first blob operation.
 	if usingSASToken(l.config) {
 		ref := l.client.GetContainerReference(id)
-		exists, err := ref.Exists()
-		if err != nil {
-			return nil, err
-		}
-		if !exists {
-			return nil, stow.ErrNotFound
-		}
 		return &container{
 			id:         id,
 			properties: ref.Properties,

--- a/azure/location.go
+++ b/azure/location.go
@@ -62,15 +62,10 @@ func (l *location) Containers(prefix, cursor string, count int) ([]stow.Containe
 }
 
 func (l *location) Container(id string) (stow.Container, error) {
-	// A user-delegation SAS token (Azure Workload Identity) is scoped to this
-	// single container (sr=c) and is authorized only for blob operations WITHIN
-	// the container. Container-level operations — listing containers, and also
-	// "Get Container Properties" (which ref.Exists() issues) — require an
-	// account-level SAS (srt=service/container/object) and return HTTP 403 with
-	// a container-scoped token, regardless of the SAS permissions or the
-	// delegated identity's RBAC. So reference the container directly without any
-	// existence/property probe; a genuinely missing container surfaces on the
-	// first blob operation.
+	// A container-scoped SAS token can't do container-level ops like Get
+	// Container Properties (used by ref.Exists()) — it 403s regardless of
+	// RBAC — so skip the probe and reference the container directly; a
+	// missing container surfaces on the first blob operation.
 	if usingSASToken(l.config) {
 		ref := l.client.GetContainerReference(id)
 		return &container{

--- a/azure/location.go
+++ b/azure/location.go
@@ -62,6 +62,26 @@ func (l *location) Containers(prefix, cursor string, count int) ([]stow.Containe
 }
 
 func (l *location) Container(id string) (stow.Container, error) {
+	// A user-delegation SAS token (Azure Workload Identity) is scoped to this
+	// container and cannot list containers at the account level. Reference the
+	// container directly and confirm it with a container-scoped existence check
+	// instead of enumerating.
+	if usingSASToken(l.config) {
+		ref := l.client.GetContainerReference(id)
+		exists, err := ref.Exists()
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			return nil, stow.ErrNotFound
+		}
+		return &container{
+			id:         id,
+			properties: ref.Properties,
+			client:     l.client,
+		}, nil
+	}
+
 	cursor := stow.CursorStart
 	for {
 		containers, crsr, err := l.Containers(id[:3], cursor, 100)


### PR DESCRIPTION
Adds a `ConfigSASToken` config key as an alternative to the existing
account+key auth, letting callers authenticate with a pre-minted SAS
token (e.g. from Azure Workload Identity / federated-identity
credentials) instead of a static shared key.

`ConfigSASToken` is an alternative to `ConfigKey`, not additive —
either one satisfies validation. When a SAS token is supplied,
`newBlobStorageClient` builds the blob endpoint from the account name
and the configured (or public) cloud's storage suffix, and constructs
the client via `az.NewAccountSASClientFromEndpointToken`. Existing
account+key auth is unchanged.

container.go/item.go/location.go/multipart.go are unaffected — they
all consume the resulting `*az.BlobStorageClient` generically
regardless of auth method.

Test plan:
- `go build ./...`, `go vet ./azure/...`, `gofmt -l` all clean
- `go test ./azure/... -v` — new tests
  (`TestNewBlobStorageClientSASToken`,
  `TestValidateAcceptsAccountAndSASTokenWithoutKey`,
  `TestValidateRejectsAccountOnly`) pass; pre-existing live-Azure tests
  skip as before (unrelated, gated on env vars)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure Blob Storage authentication using SAS tokens alongside account keys.
  * Enabled direct container access with SAS-token authentication.
  * Added support for account and SAS-token configurations without an account key.
* **Bug Fixes**
  * Rejects SAS tokens that permit non-HTTPS connections.
  * Improved credential validation and error handling.
* **Tests**
  * Added coverage for SAS-token client creation, HTTPS enforcement, and authentication validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->